### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ All of these features are on by default but can be disabled with flags.
   but you can pass in ``--randomly-seed`` to repeat a randomness-induced
   failure.
 * If
-  `factory boy <https://factoryboy.readthedocs.org/en/latest/reference.html>`_
+  `factory boy <https://factoryboy.readthedocs.io/en/latest/reference.html>`_
   is installed, its random state is reset at the start of every test. This
   allows for repeatable use of its random 'fuzzy' features.
 * If `faker <https://pypi.python.org/pypi/fake-factory>`_ is installed, its


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.