### PR TITLE
Don't reseed before test calls

### DIFF
--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -78,11 +78,6 @@ def pytest_runtest_setup(item):
         _reseed(item.config)
 
 
-def pytest_runtest_call(item):
-    if item.config.getoption('randomly_reset_seed'):
-        _reseed(item.config)
-
-
 def pytest_runtest_teardown(item):
     if item.config.getoption('randomly_reset_seed'):
         _reseed(item.config)


### PR DESCRIPTION
Thanks for this plugin, it's definitely made our tests better. However, I think we've run into a bug when using fixtures with random data.

This patch changes the reseeding behavior to only reseed at test setup/teardown, but not again when running the test. This means that the state will no longer be reset between a fixture and the test using the fixture, which enables tests like this to work as expected:

```python
import random
import pytest

@pytest.fixture
def random_number():
    return random.random()

def test_something(random_number):
    new_number = random.random()
    assert new_number != random_number
```

This example is simple, but becomes important when fixtures use Factory-Boy to generate more complex random data.