### PR TITLE
Add: py26 compat

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,5 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Grégory Starck <g.starck@gmail.com>
+* ..

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ History
 Pending Release
 ---------------
 
-* New release notes here
+* Add support for python2.6
 
 1.1.0 (2016-09-12)
 ------------------

--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -68,7 +68,7 @@ def pytest_report_header(config):
     if config.getoption('randomly_reset_seed'):
         _reseed(config)
         seed = config.getoption('randomly_seed')
-        out = "Using --randomly-seed={}".format(seed)
+        out = "Using --randomly-seed={0}".format(seed)
 
     return out
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
Hi,

This allows one to use pytest-randomly with python 2.6. (I know it's old but some industry are slow to move..)

Thx.