### PR TITLE
reseed the config even when dont-reset-seed is set

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ Pending Release
 
 * New release notes here
 * Dropped Python 2.6 compatibility, as upstream dependency NumPy did.
+* Always print the current random seed, even if not resetting it, so tests can be reproduced in case of failure
 
 1.1.2 (2016-10-27)
 ------------------

--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -78,12 +78,9 @@ def _reseed(config, offset=0):
 
 
 def pytest_report_header(config):
-    out = None
-
-    if config.getoption('randomly_reset_seed'):
-        _reseed(config)
-        seed = config.getoption('randomly_seed')
-        out = "Using --randomly-seed={0}".format(seed)
+    _reseed(config)
+    seed = config.getoption('randomly_seed')
+    out = "Using --randomly-seed={0}".format(seed)
 
     return out
 
@@ -106,9 +103,6 @@ def pytest_runtest_teardown(item):
 def pytest_collection_modifyitems(session, config, items):
     if not config.getoption('randomly_reorganize'):
         return
-
-    if config.getoption('randomly_reset_seed'):
-        _reseed(config)
 
     module_items = []
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 docutils
 flake8
+faker
 isort
 modernize
 multilint

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@
 configparser==3.5.0       # via flake8
 docutils==0.13.1
 enum34==1.1.6             # via flake8
+faker==0.7.17
 flake8==3.3.0
+ipaddress==1.0.18         # via faker
 isort==4.2.15
 mccabe==0.6.1             # via flake8
 modernize==0.5
@@ -18,4 +20,5 @@ pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8
 pygments==2.2.0
 pytest==3.1.2
+python-dateutil==2.6.0    # via faker
 six==1.10.0


### PR DESCRIPTION
Hello @adamchainz 

When using --randomly-dont-reset-seed, we loose the possibility to specify a seed, and as consequence to keep a stable ordering of tests. 

I slightly modified it so that the seed is always printed, no matter what is the setting for dont-reset-seed. It gives you a chance to make a second call, keeping the same ordering, and the same "global" seed, event if it's not reset between tests and/or testcases.

Additionally, I added a test for faker, using the same principle used for numpy.